### PR TITLE
Fix number of generated SIFT features

### DIFF
--- a/FriedLiver/Source/Bundler.cpp
+++ b/FriedLiver/Source/Bundler.cpp
@@ -58,7 +58,7 @@ void Bundler::initSift(unsigned int widthSift, unsigned int heightSift, bool isL
 {
 	if (isLocal) {
 		m_sift = new SiftGPU;
-		m_sift->SetParams(widthSift, heightSift, false, 150, GlobalAppState::get().s_sensorDepthMin, GlobalAppState::get().s_sensorDepthMax);
+		m_sift->SetParams(widthSift, heightSift, false, GlobalBundlingState::get().s_maxNumKeysPerImage, GlobalAppState::get().s_sensorDepthMin, GlobalAppState::get().s_sensorDepthMax);
 		m_sift->InitSiftGPU();
 	}
 	else {

--- a/FriedLiver/Source/SiftGPU/SiftPyramid.cpp
+++ b/FriedLiver/Source/SiftGPU/SiftPyramid.cpp
@@ -245,11 +245,20 @@ void SiftPyramid::LimitFeatureCount(int have_keylist)
 	else
 	{
 		int i = 0, num_to_erase = 0;
+		//remove remaining levels before the number of features drops below the threshold.
 		while (_featureNum - _levelFeatureNum[i] > _FeatureCountThreshold)
 		{
 			num_to_erase += _levelFeatureNum[i];
 			_featureNum -= _levelFeatureNum[i];
 			_levelFeatureNum[i++] = 0;
+		}
+		//clamp number of features in the last contributing level.
+		if (_featureNum > _FeatureCountThreshold)
+		{
+			int num_to_erase_last = _featureNum - _FeatureCountThreshold;
+			num_to_erase += num_to_erase_last;
+			_featureNum -= num_to_erase_last;
+			_levelFeatureNum[i] -= num_to_erase_last;
 		}
 	}
 }
@@ -745,7 +754,7 @@ void SiftPyramid::CreateGlobalKeyPointList(float4* d_keypoints, const float* d_d
 
 	//if needed, eliminate lower level keypoints first
 	std::vector<int> numKeysPerLevel(n, 0); int cur = 0;
-	const bool bHasMax = maxNumKeyPoints == (unsigned int)-1;
+	const bool bHasMax = maxNumKeyPoints != (unsigned int)-1;
 	for (int i = n - 1; i >= 0; i--) {
 		if (!bHasMax) numKeysPerLevel[i] = _levelFeatureNum[i];
 		else {

--- a/FriedLiver/zParametersBundlingDefault.txt
+++ b/FriedLiver/zParametersBundlingDefault.txt
@@ -29,7 +29,7 @@ s_denseOverlapCheckSubsampleFactor = 4;
 
 s_maxNumImages = 1200;
 s_submapSize = 10;
-s_maxNumKeysPerImage = 1024;
+s_maxNumKeysPerImage = 150;
 
 s_useLocalDense = true;
 s_numOptPerResidualRemoval = 1; 


### PR DESCRIPTION
While playing around with the SIFT feature extractor, I observed the following problems:

- When creating the keypoint list, the flag `bHasMax` is defined the wrong way which would lead to unexpected behaviour in no limit is set. If there is a limit, then too many features are copied, but this is handled implicitly later on making this hard to recognize.

- I observed that in many cases the number of extracted features (at least what is returned by `GetFeatureNum()`) exceed the specified limit. The function `LimitFeatureCount()` removes overflowing levels iteratively until the count would drop below the limit in the next iteration. This is fixed by partially removing this last contributing level to match the limit.

- Although the feature extraction limit can be controlled in the config file, the Bundler uses a hard-coded number of `150`. Since the value in the config file is `1024`, the above errors were unfortunately not catched. The second commit adjusts the config file and removes the hard-coded value.