### PR TITLE
Fix rare failure in match sort kernel

### DIFF
--- a/FriedLiver/Source/SiftGPU/SIFTImageManager.cu
+++ b/FriedLiver/Source/SiftGPU/SIFTImageManager.cu
@@ -104,7 +104,8 @@ void __global__ SortKeyPointMatchesCU_Kernel(
 	__shared__ bool swapped;
 	swapped = true;
 	unsigned int run = 0;
-	while (swapped) {
+	//at least one odd phase is required
+	while (swapped || run < 2) {
 		swapped = false;
 
 		unsigned int idx0 = 2 * tidx + 0;


### PR DESCRIPTION
The sort kernel uses Parallel Bubble Sort and switches between even and odd phases. In the rare case where every even pair is sorted but not the whole sequence, no swap will be performed during the initial even phase. Therefore, the sequence is considered sorted, the loop stops and no odd phase is triggered. This case becomes more likely for short sequences like this one here:

1 2 5 6 3 4

Even phase checks : 1 < 2, 5 < 6, 3 < 4 --> no swap performed

This issue is fixed by enforcing that at least one even and odd phase is performed.