### PR TITLE
Fix GPU hangs in SiftGPU

### DIFF
--- a/FriedLiver/Source/SiftGPU/ProgramCU.cu
+++ b/FriedLiver/Source/SiftGPU/ProgramCU.cu
@@ -989,7 +989,7 @@ void __global__ ComputeOrientation_Kernel(float4* d_list,
 			const unsigned int p = (tidx + 1) % 36;
 			target[tidx] = (source[m] + source[c] + source[p])*one_third;
 
-			__syncthreads();
+			__threadfence();
 			volatile float *tmp = source;
 			source = target;
 			target = tmp;
@@ -1100,8 +1100,8 @@ void __global__ ComputeOrientation_Kernel(float4* d_list,
 	__syncthreads();
 	if (tidx == 0) {
 		weights[maxIndex] = -1.0f;
-		__syncthreads();
 	}
+	__syncthreads();
 
 	// 2nd reduction to compute 2nd max weight
 	for (unsigned int stride = COMPUTE_ORIENTATION_BLOCK / 2; stride > 0; stride /= 2) {


### PR DESCRIPTION
Running BundleFusion on a RTX graphics card causes the GPU to hang due to thread synchronization bugs (see #51). For some reason, this problem does not occur on previous graphics cards.

Fix the synchronization bugs in the `__global__ void ComputeOrientation_Kernel(...)` by replacing the conditional `__syncthreads()` calls with unconditional ones. Thread synchronization requires that **all** threads reach the call, otherwise the GPU hangs and waits for the remaining ones, which will of course never happen due to the `if` condition.